### PR TITLE
prefer the database name supplied from config

### DIFF
--- a/src/db2g.js
+++ b/src/db2g.js
@@ -157,7 +157,7 @@ class DB2Graphql {
    * 
    * @returns {Promise}                 The self instance for fluent interface
    */
-  async connect(namespace = 'public') {
+  async connect(namespace = '') {
     if (!this.connection) throw new Error('Invalid Knex instance');
 
     const config = this.connection.connection().client.config;
@@ -165,6 +165,9 @@ class DB2Graphql {
     if (!this.drivers[drivername]) {
       throw new Error('Database driver not available');
     }
+
+    config.connection = config.connection || {};
+    namespace = namespace || config.connection.database || 'public';
 
     this.dbDriver = new this.drivers[drivername](this.connection);
     this.dbSchema = await this.dbDriver.getSchema(namespace, config.exclude);


### PR DESCRIPTION
preserve the 'public' schema default as a final fallback after preferring the supplied database name (if any) that was passed in with the connection configuration

note: if we can depend on config.connection being defined then we can ditch the guard